### PR TITLE
Fix source directory

### DIFF
--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -14,7 +14,7 @@ failedfiles = manager.list()
 currentdir = os.path.realpath(os.getcwd()).rstrip(os.sep)
 print("Arguments: " + str(sys.argv))
 # Get absolute source dir after removing leading and trailing seperators from input. 
-sourcedir = currentdir + sys.argv[1].lstrip(os.sep).rstrip(os.sep)
+sourcedir = os.path.join(currentdir,sys.argv[1].lstrip(os.sep).rstrip(os.sep))
 print("Source directory: " + sourcedir)
 excludedirs = ()
 if sys.argv[2]:


### PR DESCRIPTION
Use `os.path.join` to avoid bad construction of source directory.