### PR TITLE
Erdinc/ren 296 clang format is beginning to break

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
+# This is largely copied from https://github.com/HorstBaerbel/ccpp-cmake-build-and-test
+# But, we just get clang-format-12 from ubuntu-rolling (ubuntu:latest currently 20.04 doesn't have it).
 FROM ubuntu:rolling
 
 WORKDIR /
 
+# Timezone setup might be needed in order for packages to install properly.
 ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,17 @@ ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt update
 RUN apt -y dist-upgrade
-RUN apt -y install clang-format-14
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
+
+# Download clang-format-16 since ubuntu repos does not have it right now
+# TODO: Change it with `apt install clang-format-16` when ubuntu has it.
+RUN apt -y install wget
+RUN wget --no-check-certificate -O clang-format "https://drive.google.com/uc?export=download&id=1QCpf_BD_o_1vXyFQmis3DuorSfByRX4X"
+RUN chmod +x clang-format
+RUN mv clang-format /usr/bin/
+
+# Dependencies for clang-format and python file.
+RUN apt -y install libncurses5
+RUN apt -y install python3
 
 RUN apt -y autoclean
 RUN apt -y clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is largely copied from https://github.com/HorstBaerbel/ccpp-cmake-build-and-test
-# But, we just get clang-format-12 from ubuntu-rolling (ubuntu:latest currently 20.04 doesn't have it).
+# But, we just get a modern clang-format.
 FROM ubuntu:rolling
 
 WORKDIR /
@@ -9,8 +9,8 @@ ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt update
 RUN apt -y dist-upgrade
-RUN apt -y install clang-format-12
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100
+RUN apt -y install clang-format-14
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
 
 RUN apt -y autoclean
 RUN apt -y clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,14 @@ RUN apt update
 RUN apt -y dist-upgrade
 
 # Download clang-format-16 since ubuntu repos does not have it right now
+# The executable file is belong to clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+# which contains all executables from clang-16. To make the download lighter,
+# I only extracted the clang-format-16.
+# Here you can find the clang-format download page and the all files
+# https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.0
 # TODO: Change it with `apt install clang-format-16` when ubuntu has it.
 RUN apt -y install wget
-RUN wget --no-check-certificate -O clang-format "https://drive.google.com/uc?export=download&id=1QCpf_BD_o_1vXyFQmis3DuorSfByRX4X"
+RUN wget --no-verbose --referer=https://veed.io https://cdn.veed.dev/rendernodeBuildDeps/clang-format/v16/clang-format
 RUN chmod +x clang-format
 RUN mv clang-format /usr/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM horstbaerbel/ccpp-cmake-build-and-test:1.0
+FROM ubuntu:rolling
+
+WORKDIR /
+
+ENV TZ=Europe/Berlin
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt update
+RUN apt -y dist-upgrade
+RUN apt -y install clang-format-12
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100
+
+RUN apt -y autoclean
+RUN apt -y clean
+RUN rm -rf /var/lib/apt/lists/*
 
 LABEL "com.github.actions.name"="action-clang-format"
 LABEL "com.github.actions.description"="Run clang-format on source directory"

--- a/README.md
+++ b/README.md
@@ -20,29 +20,29 @@ name: Clang-format
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   checkout-and-check-formatting:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Run clang-format
-      uses: HorstBaerbel/action-clang-format@1.4
-      # These are optional (defaults displayed)
-      with:
-        scandir: '.'
-        excludedirs: 'build'
-        extensions: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
-        style: 'file'
+      - uses: actions/checkout@v2
+      - name: Run clang-format
+        uses: HorstBaerbel/action-clang-format@1.4
+        # These are optional (defaults displayed)
+        with:
+          scandir: "."
+          excludedirs: "build"
+          extensions: "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx"
+          style: "file"
 ```
 
 ## Parameters (optional), see action.yml
 
-* **scandir**: Directory to scan, e.g. 'src'. MUST be realtive to you repository, thus '.' means root of repository. MUST contain a valid CMakeLists.txt.
-* **excludedirs**: Directories below scandir to exclude from scanning, e.g. "build,test,src/third_party". MUST be relative to scandir, thus 'test' means 'scandir/test'.
-* **extensions**: Extensions to include in scan, e.g. 'h,c,hpp,cpp'.
-* **style**: Style string to pass to clang-format. Use 'file' to make clang-format use a [.clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) file.
+- **scandir**: Directory to scan, e.g. 'src'. MUST be realtive to you repository, thus '.' means root of repository. eg: `./src/` or `src/`
+- **excludedirs**: Directories below scandir to exclude from scanning, e.g. "build,test,src/third_party". MUST be relative to scandir, thus 'test' means 'scandir/test'.
+- **extensions**: Extensions to include in scan, e.g. 'h,c,hpp,cpp'.
+- **style**: Style string to pass to clang-format. Use 'file' to make clang-format use a [.clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) file.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,5 @@
 # Terminate upon errors
 set -e
 # Run format script
+clang-format --version
 python3 /run-clang-format.py "${INPUT_SCANDIR}" "${INPUT_EXCLUDEDIRS}" "${INPUT_EXTENSIONS}" "${INPUT_STYLE}"

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -48,7 +48,7 @@ pool.map(runclangformat, collectfiles(sourcedir, excludedirs, extensions))
 pool.close()
 pool.join()
 if len(failedfiles) > 0:
-    print("Errors in " + len(failedfiles) + " files")
+    print("Errors in " + str(len(failedfiles)) + " files")
     sys.exit(1)
 print("No errors found")
 sys.exit(0)

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -14,7 +14,7 @@ failedfiles = manager.list()
 currentdir = os.path.realpath(os.getcwd())
 print("Arguments: " + str(sys.argv))
 # Get absolute source dir after removing leading and trailing seperators from input. 
-sourcedir = currentdir + sys.argv[1].lstrip(os.sep).rstrip(os.sep)
+sourcedir = currentdir + os.sep + sys.argv[1].lstrip(os.sep).rstrip(os.sep)
 print("Source directory: " + sourcedir)
 excludedirs = ()
 if sys.argv[2]:

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -26,7 +26,7 @@ style = sys.argv[4]
 print("Style: " + style)
 
 def runclangformat(filepath):
-    print("Checking: " + filepath)
+    # print("Checking: " + filepath)
     # See: https://stackoverflow.com/questions/22866609/can-clang-format-tell-me-if-formatting-changes-are-necessary
     proc = subprocess.Popen("clang-format -style=" + style + " " + filepath + " | diff -u --color=always " + filepath + " -", shell=True)
     if proc.wait() != 0:

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -11,7 +11,7 @@ manager = multiprocessing.Manager()
 failedfiles = manager.list()
 
 # Get absolute current path and remove trailing seperators
-currentdir = os.path.realpath(os.getcwd()).rstrip(os.sep)
+currentdir = os.path.realpath(os.getcwd())
 print("Arguments: " + str(sys.argv))
 # Get absolute source dir after removing leading and trailing seperators from input. 
 sourcedir = currentdir + sys.argv[1].lstrip(os.sep).rstrip(os.sep)


### PR DESCRIPTION
## Why
The clang-format-14 was breaking some ankles with its weird indentations. Therefore we wanted to pop the version to the modern one which is 16

## What
Pops the clang-format version from 14 to 16

## Test
No need to test